### PR TITLE
cmake: Added macros for x86_64 for future use

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -47,6 +47,8 @@ function(libxaac_add_definitions)
     add_definitions(-DARMV7)
   elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "i686")
     add_definitions(-DX86 -D_X86_)
+  elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    add_definitions(-DX86_64 -D_X86_64_)
   endif()
 endfunction()
 


### PR DESCRIPTION
Added macros for x86_64 in libxaac_add_definitions in utils.cmake which will be useful in the future for any x86_64 specific usecase.