### PR TITLE
Android.bp: Fix riscv64 build for decoder

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -338,6 +338,19 @@ cc_library_static {
                 "decoder/x86_64/ixheaacd_function_selector_x86_64.c",
             ],
         },
+
+        riscv64: {
+            cflags: [
+            ],
+
+            local_include_dirs: [
+            ],
+
+            srcs: [
+                "decoder/generic/ixheaacd_qmf_dec_generic.c",
+                "decoder/generic/ixheaacd_function_selector_generic.c",
+            ],
+        },
     },
 }
 

--- a/decoder/generic/ixheaacd_function_selector_generic.c
+++ b/decoder/generic/ixheaacd_function_selector_generic.c
@@ -77,6 +77,10 @@ VOID(*ixheaacd_covariance_matrix_calc_960)
 (WORD32 *, ia_lpp_trans_cov_matrix *,
  WORD32, WORD32) = &ixheaacd_covariance_matrix_calc_dec_960;
 
+VOID(*ixheaacd_aac_ld_dec_rearrange_960)
+(WORD32 *ip, WORD32 *op, WORD32 mdct_len_2,
+ WORD16 *re_arr_tab) = &ixheaacd_dec_rearrange_short;
+
 VOID(*ixheaacd_covariance_matrix_calc_2)
 (ia_lpp_trans_cov_matrix *, WORD32 *, WORD32,
  WORD16) = &ixheaacd_covariance_matrix_calc_2_dec;


### PR DESCRIPTION
- Add appropriate entries in Android.bp for riscv64 for decoder
- Add missing function in function_selector_generic.c