### PR TITLE
Fix for Use-of-uninitialized-value in ixheaacd_aacdec_decodeframe

### DIFF
--- a/decoder/ixheaacd_api.c
+++ b/decoder/ixheaacd_api.c
@@ -2023,6 +2023,7 @@ IA_ERRORCODE ixheaacd_dec_init(
 
     while ((type != 7)) {
       ia_aac_dec_scratch_struct aac_scratch_struct;
+      memset(&aac_scratch_struct, 0, sizeof(aac_scratch_struct));
 
       if (ch_idx >= elements_number) {
         p_state_enhaacplus_dec->i_bytes_consumed = 1;


### PR DESCRIPTION
These changes fix the Use-of-uninitialized-value in ixheaacd_aacdec_decodeframe runtime error
caused due to uninitialized structure members of aac scratch structure.

Bug: ossFuzz:68464
Test: poc in bug

Testing:
[x] All previous fuzzer crashes are tested. No crash observed.
[x] CTS and Conformance for msvs, x86, x86_64, armv7 and armv8 are passing.