### PR TITLE
Initialize local scratch structure before first use in non-USAC control paths

### DIFF
--- a/decoder/ixheaacd_api.c
+++ b/decoder/ixheaacd_api.c
@@ -3184,6 +3184,8 @@ IA_ERRORCODE ixheaacd_dec_execute(
     {
       WORD element_index_order1[MAX_BS_ELEMENT];
       ia_aac_dec_scratch_struct aac_scratch_struct;
+      memset(&aac_scratch_struct, 0, sizeof(aac_scratch_struct));
+
       ixheaacd_allocate_aac_scr(
           &aac_scratch_struct, p_state_enhaacplus_dec->aac_scratch_mem_v,
           time_data, channel, p_obj_exhaacplus_dec->aac_config.ui_max_channels,


### PR DESCRIPTION
Significance:
--------------
- Possibility of accessing uninitialized access to structure members of a local scratch structure uncovered with fuzzer testing.
- The changes in this commit handle such cases.

Bug: ossFuzz:68464
Test: poc in bug

Testing:
--------------
- All previous fuzzer crashes are tested. No crash observed.
- CTS and Conformance for msvs, x86, x86_64, armv7 and armv8 are passing.