### PR TITLE
Added a fix in the FAC payload writing path

### DIFF
--- a/encoder/iusace_enc_fac.c
+++ b/encoder/iusace_enc_fac.c
@@ -520,16 +520,17 @@ WORD32 iusace_fd_encode_fac(WORD32 *prm, WORD16 *ptr_bit_buf, WORD32 fac_length)
       n = qn - nk * 2;
     }
 
-    if (n != 0) {
+    if (qn != 0) {
       iusace_write_bits2buf(I, 4 * n, ptr_bit_buf);
       ptr_bit_buf += 4 * n;
-    }
-    for (j = 0; j < 8; j++) {
-      iusace_write_bits2buf(kv[j], nk, ptr_bit_buf);
-      ptr_bit_buf += nk;
-    }
 
-    fac_bits += 4 * qn;
+      for (j = 0; j < 8; j++) {
+        iusace_write_bits2buf(kv[j], nk, ptr_bit_buf);
+        ptr_bit_buf += nk;
+      }
+
+      fac_bits += 4 * qn;
+    }
   }
 
   return fac_bits;


### PR DESCRIPTION
- The bit-writing logic had to be skipped when no bits were to be written. Added the missing check for the same.
- This change also resolves an issue identified by oss-fuzz.

Bug: ossFuzz: 68476
Test: poc in bug