### PR TITLE
Added a fix in the FAC payload writing path

### DIFF
--- a/encoder/iusace_enc_fac.c
+++ b/encoder/iusace_enc_fac.c
@@ -523,14 +523,14 @@ WORD32 iusace_fd_encode_fac(WORD32 *prm, WORD16 *ptr_bit_buf, WORD32 fac_length)
     if (qn != 0) {
       iusace_write_bits2buf(I, 4 * n, ptr_bit_buf);
       ptr_bit_buf += 4 * n;
-
+    }
+    if (qn > 4) {
       for (j = 0; j < 8; j++) {
         iusace_write_bits2buf(kv[j], nk, ptr_bit_buf);
         ptr_bit_buf += nk;
       }
-
-      fac_bits += 4 * qn;
     }
+    fac_bits += 4 * qn;
   }
 
   return fac_bits;


### PR DESCRIPTION
- The bit-writing logic had to be skipped when no bits were to be written. Updated the existing check for the same.
- This change also resolves an issue identified by oss-fuzz.

Bug: ossFuzz: 69103
Test: poc in bug