### PR TITLE
Fix clang-16 (x86_64) build warnings and SBR range start frequency border for 4:1 system issue

### DIFF
--- a/decoder/ixheaacd_block.h
+++ b/decoder/ixheaacd_block.h
@@ -109,9 +109,8 @@ VOID ixheaacd_set_corr_info(
 VOID ixheaacd_gen_rand_vec(WORD32 scale, WORD shift, WORD32 *spec,
                            WORD32 sfb_width, WORD32 *random_vec);
 
-VOID ixheaacd_pns_process(
-    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[], WORD32 channel,
-    ia_aac_dec_tables_struct *ptr_aac_tables);
+VOID ixheaacd_pns_process(ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[CHANNELS],
+                          WORD32 channel, ia_aac_dec_tables_struct *ptr_aac_tables);
 
 VOID ixheaacd_spec_to_overlapbuf_dec(WORD32 *ptr_overlap_buf,
                                      WORD32 *ptr_spec_coeff, WORD32 q_shift,

--- a/decoder/ixheaacd_channel.c
+++ b/decoder/ixheaacd_channel.c
@@ -600,11 +600,10 @@ VOID ixheaacd_read_ms_data(
 }
 
 IA_ERRORCODE ixheaacd_channel_pair_process(
-    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[], WORD32 num_ch,
-    ia_aac_dec_tables_struct *ptr_aac_tables, WORD32 total_channels,
-    WORD32 object_type, WORD32 aac_spect_data_resil_flag,
-    WORD32 aac_sf_data_resil_flag, WORD32 *in_data, WORD32 *out_data,
-    void *self_ptr) {
+    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[CHANNELS], WORD32 num_ch,
+    ia_aac_dec_tables_struct *ptr_aac_tables, WORD32 total_channels, WORD32 object_type,
+    WORD32 aac_spect_data_resil_flag, WORD32 aac_sf_data_resil_flag, WORD32 *in_data,
+    WORD32 *out_data, void *self_ptr) {
   WORD32 channel;
   IA_ERRORCODE err = IA_NO_ERROR;
   ia_aac_decoder_struct *self = self_ptr;

--- a/decoder/ixheaacd_channel.h
+++ b/decoder/ixheaacd_channel.h
@@ -41,11 +41,10 @@ enum {
 #define RIGHT 1
 
 IA_ERRORCODE ixheaacd_channel_pair_process(
-    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[], WORD32 num_ch,
-    ia_aac_dec_tables_struct *ptr_aac_tables, WORD32 total_channels,
-    WORD32 object_type, WORD32 aac_spect_data_resil_flag,
-    WORD32 aac_sf_data_resil_flag, WORD32 *in_data, WORD32 *out_data,
-    void *self_ptr);
+    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[CHANNELS], WORD32 num_ch,
+    ia_aac_dec_tables_struct *ptr_aac_tables, WORD32 total_channels, WORD32 object_type,
+    WORD32 aac_spect_data_resil_flag, WORD32 aac_sf_data_resil_flag, WORD32 *in_data,
+    WORD32 *out_data, void *self_ptr);
 
 VOID ixheaacd_map_ms_mask_pns(
     ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[CHANNELS]);

--- a/decoder/ixheaacd_freq_sca.c
+++ b/decoder/ixheaacd_freq_sca.c
@@ -696,7 +696,8 @@ WORD32 ixheaacd_calc_frq_bnd_tbls(ia_sbr_header_data_struct *ptr_header_data,
 
   ptr_header_data->status = 1;
 
-  if ((lsb > NO_ANALYSIS_CHANNELS) || (lsb >= usb)) {
+  if ((lsb > ((ptr_header_data->sbr_ratio_idx == SBR_UPSAMPLE_IDX_4_1) ? 16 : 32)) ||
+      (lsb >= usb)) {
     return -1;
   }
 

--- a/decoder/ixheaacd_mps_parse.c
+++ b/decoder/ixheaacd_mps_parse.c
@@ -688,8 +688,7 @@ static VOID ixheaacd_ld_mps_ecdata_decoding(
     ia_mps_dec_state_struct *self, ia_bit_buf_struct *it_bit_buff,
     WORD32 data[MAX_PARAMETER_SETS_MPS][MAX_PARAMETER_BANDS], WORD32 datatype,
     WORD32 start_band) {
-  WORD32 i, j, pb, data_set, set_index, bs_data_pair, data_bands,
-      old_quant_coarse_xxx;
+  WORD32 i, j, pb, set_index, bs_data_pair, data_bands, old_quant_coarse_xxx;
   WORD32 strides[MAX_PARAMETER_BANDS + 1] = {0};
   WORD32 band_stop = 0;
 
@@ -716,13 +715,9 @@ static VOID ixheaacd_ld_mps_ecdata_decoding(
     lastdata = frame->cmp_cld_idx_prev;
     band_stop = self->bs_param_bands;
   }
-  data_set = 0;
   for (i = 0; i < self->num_parameter_sets; i++) {
     frame_xxx_data->bs_xxx_data_mode[i] =
         ixheaacd_read_bits_buf(it_bit_buff, 2);
-    if (frame_xxx_data->bs_xxx_data_mode[i] == 3) {
-      data_set++;
-    }
   }
 
   set_index = 0;

--- a/decoder/ixheaacd_mps_polyphase.c
+++ b/decoder/ixheaacd_mps_polyphase.c
@@ -826,7 +826,7 @@ VOID ixheaacd_calculate_syn_filt_bank_res64(ia_mps_dec_qmf_syn_filter_bank *syn,
   p_si = si;
   for (k = 0; k < nr_samples; k++) {
     WORD32 *new_samp = p_si;
-    WORD32 *new_samp1, *new_samp2;
+    WORD32 *new_samp2;
 
     ixheaacd_inverse_modulation(p_sr, p_si, qmf_table_ptr);
 
@@ -872,7 +872,6 @@ VOID ixheaacd_calculate_syn_filt_bank_res64(ia_mps_dec_qmf_syn_filter_bank *syn,
 
     syn_buf_p2 = synth_buf;
     syn_buf_p3 = syn_buf_p2;
-    new_samp1 = p_sr + 1;
     new_samp2 = p_sr + 63;
     for (j = 0; j < resolution - 1; j++) {
       *time_sig-- = ixheaac_add32_sat(syn_buf_p3[512],
@@ -898,7 +897,6 @@ VOID ixheaacd_calculate_syn_filt_bank_res64(ia_mps_dec_qmf_syn_filter_bank *syn,
       new_samp++;
       syn_buf_p2++;
 
-      new_samp1++;
       new_samp2--;
       syn_buf_p3++;
     }

--- a/decoder/ixheaacd_pns_js_thumb.c
+++ b/decoder/ixheaacd_pns_js_thumb.c
@@ -111,9 +111,8 @@ VOID ixheaacd_gen_rand_vec(WORD32 scale, WORD shift, WORD32 *ptr_spec_coef,
   }
 }
 
-VOID ixheaacd_pns_process(
-    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[], WORD32 channel,
-    ia_aac_dec_tables_struct *ptr_aac_tables) {
+VOID ixheaacd_pns_process(ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[CHANNELS],
+                          WORD32 channel, ia_aac_dec_tables_struct *ptr_aac_tables) {
   ia_pns_info_struct *ptr_pns_info =
       &ptr_aac_dec_channel_info[channel]->str_pns_info;
   ia_ics_info_struct *ptr_ics_info =

--- a/decoder/ixheaacd_sbr_dec.h
+++ b/decoder/ixheaacd_sbr_dec.h
@@ -294,10 +294,9 @@ VOID ixheaacd_rescale_x_overlap(
     WORD32 **pp_overlap_buffer_real, WORD32 **pp_overlap_buffer_imag,
     FLAG low_pow_flag);
 
-WORD32 ixheaacd_qmf_hbe_data_reinit(
-    ia_esbr_hbe_txposer_struct *ptr_hbe_transposer_str,
-    WORD16 *ptr_freq_band_tbl[MAX_FREQ_COEFFS + 1], WORD16 *ptr_num_sf_bands,
-    WORD32 upsamp_4_flag);
+WORD32 ixheaacd_qmf_hbe_data_reinit(ia_esbr_hbe_txposer_struct *ptr_hbe_transposer_str,
+                                    WORD16 *ptr_freq_band_tbl[2], WORD16 *ptr_num_sf_bands,
+                                    WORD32 upsamp_4_flag);
 
 WORD32 ixheaacd_dft_hbe_data_reinit(ia_esbr_hbe_txposer_struct *ptr_hbe_txposer,
                                     WORD16 *p_freq_band_tab[2], WORD16 *p_num_sfb);

--- a/decoder/ixheaacd_sbrqmftrans.h
+++ b/decoder/ixheaacd_sbrqmftrans.h
@@ -36,10 +36,9 @@ WORD32 ixheaacd_dft_hbe_apply(ia_esbr_hbe_txposer_struct *ptr_hbe_txposer,
                               WORD32 pitch_in_bins,
                               FLOAT32 *dft_hbe_scratch_buf);
 
-WORD32 ixheaacd_qmf_hbe_data_reinit(
-    ia_esbr_hbe_txposer_struct *ptr_hbe_transposer_str,
-    WORD16 *ptr_freq_band_tbl[MAX_FREQ_COEFFS + 1], WORD16 *ptr_num_sf_bands,
-    WORD32 upsamp_4_flag);
+WORD32 ixheaacd_qmf_hbe_data_reinit(ia_esbr_hbe_txposer_struct *ptr_hbe_transposer_str,
+                                    WORD16 *ptr_freq_band_tbl[2], WORD16 *ptr_num_sf_bands,
+                                    WORD32 upsamp_4_flag);
 
 IA_ERRORCODE ixheaacd_hbe_post_anal_process(ia_esbr_hbe_txposer_struct *ptr_hbe_txposer,
                                             WORD32 pitch_in_bins, WORD32 sbr_upsamp_4_flg);

--- a/decoder/ixheaacd_stereo.c
+++ b/decoder/ixheaacd_stereo.c
@@ -52,7 +52,7 @@
 #include "ixheaacd_stereo.h"
 
 VOID ixheaacd_ms_stereo_process(
-    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[2],
+    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[CHANNELS],
     ia_aac_dec_tables_struct *ptr_aac_tables)
 
 {
@@ -127,9 +127,9 @@ static PLATFORM_INLINE WORD32 ixheaacd_mult32x16in32l(WORD32 a, WORD32 b) {
 }
 
 VOID ixheaacd_intensity_stereo_process(
-    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[2],
-    ia_aac_dec_tables_struct *ptr_aac_tables, WORD32 object_type,
-    WORD32 aac_sf_data_resil_flag, WORD16 framelength) {
+    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[CHANNELS],
+    ia_aac_dec_tables_struct *ptr_aac_tables, WORD32 object_type, WORD32 aac_sf_data_resil_flag,
+    WORD16 framelength) {
   UWORD8 *ptr_ms_used =
       &ptr_aac_dec_channel_info[LEFT]->pstr_stereo_info->ms_used[0][0];
   WORD8 *ptr_code_book = &ptr_aac_dec_channel_info[RIGHT]->ptr_code_book[0];

--- a/decoder/ixheaacd_stereo.h
+++ b/decoder/ixheaacd_stereo.h
@@ -24,12 +24,12 @@ VOID ixheaacd_read_ms_data(ia_bit_buf_struct *it_bit_buff,
                            ia_aac_dec_channel_info_struct *ptr_aac_dec_ch_info);
 
 VOID ixheaacd_ms_stereo_process(
-    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[],
+    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[CHANNELS],
     ia_aac_dec_tables_struct *ptr_aac_tables);
 
 VOID ixheaacd_intensity_stereo_process(
-    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[2],
-    ia_aac_dec_tables_struct *ptr_aac_tables, WORD32 object_type,
-    WORD32 aac_sf_data_resil_flag, WORD16 framelength);
+    ia_aac_dec_channel_info_struct *ptr_aac_dec_channel_info[CHANNELS],
+    ia_aac_dec_tables_struct *ptr_aac_tables, WORD32 object_type, WORD32 aac_sf_data_resil_flag,
+    WORD16 framelength);
 
 #endif /* #ifndef IXHEAACD_STEREO_H */


### PR DESCRIPTION
Significance:
--------------
- Fixes all the the warnings observed for libxaac decoder library when compiled with clang-16 (x86_64).
- Adjusts the conditional check to validate the 4:1 system's SBR range start frequency border.

Testing:
---------
- All previous fuzzer crashes are tested. No crash observed.
- CTS and Conformance for x86, x86_64, armv7 and armv8 are passing.