### PR TITLE
Fix for UBSAN issue observed with libxaac decoder

### DIFF
--- a/decoder/ixheaacd_api.c
+++ b/decoder/ixheaacd_api.c
@@ -3679,7 +3679,7 @@ IA_ERRORCODE ixheaacd_dec_execute(
       error_code = ixheaacd_heaac_mps_apply(p_obj_exhaacplus_dec, actual_out_buffer, mps_buffer,
                                             p_state_enhaacplus_dec->ui_mps_out_bytes);
 
-      if (error_code == IA_FATAL_ERROR) {
+      if (error_code != IA_NO_ERROR) {
         return error_code;
       }
 


### PR DESCRIPTION
Significance:
- This change propogates the error returned from ixheaacd_heaac_mps_apply to ixheaacd_dec_execute.

Testing:
- All previous fuzzer crashes are tested. No crash observed.
- CTS and Conformance for x86, x86_64, armv7 and armv8 are passing.