### PR TITLE
Encoder bug fixes in the USAC path

### DIFF
--- a/encoder/ixheaace_api.c
+++ b/encoder/ixheaace_api.c
@@ -1032,6 +1032,7 @@ static IA_ERRORCODE ixheaace_set_config_params(ixheaace_api_struct *pstr_api_str
       pstr_drc_cfg->str_enc_params.sample_rate = pstr_input_config->i_samp_freq;
       pstr_drc_cfg->str_enc_params.domain = TIME_DOMAIN;
       pstr_drc_cfg->str_uni_drc_config.sample_rate = pstr_drc_cfg->str_enc_params.sample_rate;
+      if (pstr_usac_config->use_drc_element) {
       for (WORD32 i = 0; i < pstr_drc_cfg->str_uni_drc_config.drc_coefficients_uni_drc_count;
            i++) {
         for (WORD32 j = 0;
@@ -1055,7 +1056,7 @@ static IA_ERRORCODE ixheaace_set_config_params(ixheaace_api_struct *pstr_api_str
             impd_drc_get_delta_t_min(pstr_drc_cfg->str_uni_drc_config.sample_rate);
         }
       }
-
+    }
       pstr_usac_config->str_drc_cfg = *pstr_drc_cfg;
       pstr_usac_config->str_drc_cfg.str_enc_params.frame_size = pstr_usac_config->drc_frame_size;
       pstr_usac_config->str_drc_cfg.str_uni_drc_config.str_drc_coefficients_uni_drc
@@ -3125,16 +3126,6 @@ static IA_ERRORCODE iusace_process(ixheaace_api_struct *pstr_api_struct) {
 
     write_off_set = INPUT_DELAY_LC * IXHEAACE_MAX_CH_IN_BS_ELE;
 
-    if (pstr_config->use_delay_adjustment == 1) {
-      if (pstr_api_struct->config[0].ccfl_idx == SBR_4_1) {
-        write_off_set += SBR_4_1_DELAY_ADJUSTMENT * IXHEAACE_MAX_CH_IN_BS_ELE;
-      } else if (pstr_api_struct->config[0].ccfl_idx == SBR_2_1) {
-        write_off_set += SBR_2_1_DELAY_ADJUSTMENT * IXHEAACE_MAX_CH_IN_BS_ELE;
-      } else {
-        write_off_set += SBR_8_3_DELAY_ADJUSTMENT * IXHEAACE_MAX_CH_IN_BS_ELE;
-      }
-    }
-
     if (pstr_api_struct->config[0].ccfl_idx == SBR_4_1) {
       write_off_set = write_off_set * 2;
     }
@@ -3367,9 +3358,6 @@ static IA_ERRORCODE iusace_process(ixheaace_api_struct *pstr_api_struct) {
       ixheaace_get_input_scratch_buf(pstr_api_struct->pstr_state->ptr_temp_buff_resamp,
                                      &in_buffer_temp);
       if (pstr_api_struct->config[0].ccfl_idx == SBR_8_3) {
-        if (pstr_config->use_delay_adjustment == 1) {
-          delay = SBR_8_3_DELAY_ADJUSTMENT * IXHEAACE_MAX_CH_IN_BS_ELE;
-        }
         WORD32 input_tot = num_samples_read / pstr_api_struct->config[0].i_channels;
         ixheaace_upsampling_inp_buf_generation(ptr_input_buffer, in_buffer_temp, input_tot,
                                                UPSAMPLE_FAC, write_off_set - delay);
@@ -3398,13 +3386,6 @@ static IA_ERRORCODE iusace_process(ixheaace_api_struct *pstr_api_struct) {
               shared_buf1_ring, shared_buf2_ring, pstr_scratch_resampler);
         } else {
           WORD32 out_stride = IXHEAACE_MAX_CH_IN_BS_ELE * resamp_ratio;
-          if (pstr_config->use_delay_adjustment == 1) {
-            if (pstr_api_struct->config[0].ccfl_idx == SBR_2_1) {
-              delay = out_stride * SBR_2_1_DELAY_ADJUSTMENT;
-            } else {
-              delay = out_stride * SBR_4_1_DELAY_ADJUSTMENT;
-            }
-          }
           ia_enhaacplus_enc_iir_downsampler(
               &(pstr_api_struct->pstr_state->down_sampler[0][ch]),
               ptr_input_buffer + write_off_set - delay + ch,

--- a/encoder/ixheaace_fd_mdct.c
+++ b/encoder/ixheaace_fd_mdct.c
@@ -165,9 +165,9 @@ static IA_ERRORCODE iusace_fd_mdct_long(ia_usac_data_struct *pstr_usac_data,
     case LONG_STOP_SEQUENCE:
       win_len = n_short << prev_mode;
       nflat_ls = (n_long - win_len) >> 1;
-      err_code = iusace_calc_window(&ptr_win_long, n_long, window_shape);
+      err_code = iusace_calc_window(&ptr_win_long, n_long, 1);
       if (err_code) return err_code;
-      err_code = iusace_calc_window(&ptr_win_med, win_len, 1);
+      err_code = iusace_calc_window(&ptr_win_med, win_len, window_shape);
       if (err_code) return err_code;
       iusace_windowing_long_stop(ptr_overlap, ptr_win_long, ptr_windowed_buf, ptr_in_data, n_long,
                                  nflat_ls, ptr_win_med, win_len);

--- a/encoder/ixheaace_rom.h
+++ b/encoder/ixheaace_rom.h
@@ -164,9 +164,6 @@ input buffer (1ch)
 #define MAXIMUM_DS_1_3_FILTER_DELAY (36)
 
 #define CC_DELAY_ADJUSTMENT (448)
-#define SBR_2_1_DELAY_ADJUSTMENT (-70)
-#define SBR_4_1_DELAY_ADJUSTMENT (218)
-#define SBR_8_3_DELAY_ADJUSTMENT (-74)
 
 extern const FLOAT32 ixheaace_fd_quant_table[257];
 extern const FLOAT32 ixheaace_fd_inv_quant_table[257];

--- a/test/encoder/ixheaace_testbench.c
+++ b/test/encoder/ixheaace_testbench.c
@@ -1298,7 +1298,6 @@ IA_ERRORCODE ia_enhaacplus_enc_main_process(ixheaace_app_context *pstr_context, 
     return -1;
   }
   ia_drc_input_config *pstr_drc_cfg = (ia_drc_input_config *)pstr_in_cfg->pv_drc_cfg;
-  memset(pstr_drc_cfg, 0, sizeof(*pstr_drc_cfg));
 
   /* Stack process struct initing */
   p_error_init = ia_enhaacplus_enc_error_handler_init;


### PR DESCRIPTION
Significance:
==============
- Aligned STOP_WINDOW block window type selection in USAC with AAC
- Delay synchronization between USAC core coder and SBR encoder
- Minor bug fixes

Testing:
- smoke-tested on x86, x86_64, Mac, armv7, armv8 and MSVS