### PR TITLE
Enable loudness_leveling without other CLI parameter dependencies

### DIFF
--- a/README_dec.md
+++ b/README_dec.md
@@ -205,8 +205,8 @@ where,
   <esbr_ps_flag>           is to indicate eSBR with PS. Default 0.
   <interleave_to_stereo>   is to enable/disable always interleaved to stereo output. Default 1.
   <down_sample_sbr>        is to enable/disable down-sampled SBR output. Default auto identification from header.
-  <drc_cut_factor>         is to set DRC cut factor value. Default value is 0.
-  <drc_boost_factor>       is to set DRC boost factor. Default value is 0.
+  <drc_cut_factor>         is to set DRC cut factor value. Default value is 1 for USAC path and 0 for AAC path.
+  <drc_boost_factor>       is to set DRC boost factor. Default value is 1 for USAC path and 0 for AAC path.
   <drc_target_level>       is to set DRC target reference level. Default value is 108.
   <drc_heavy_compression>  is to enable/disable DRC heavy compression. Default value is 0.
   <effect_type>            is to set DRC effect type. Default value is 0.

--- a/test/decoder/ixheaacd_main.c
+++ b/test/decoder/ixheaacd_main.c
@@ -676,6 +676,7 @@ IA_ERRORCODE ixheaacd_set_config_param(WORD32 argc, pWORD8 argv[],
                                      IA_XHEAAC_DEC_CONFIG_PARAM_DRC_LOUDNESS_LEVELING,
                                      &loudness_leveling_flag);
       _IA_HANDLE_ERROR(p_proc_err_info, (pWORD8) "", err_code);
+      mpeg_d_drc_on = 1;
     }
 #endif
   }
@@ -2325,8 +2326,10 @@ void print_usage() {
   printf("\n    interleaved to stereo output. Default 1 ");
   printf("\n  <down_sample_sbr> is to enable/disable down-sampled SBR ");
   printf("\n    output. Default auto identification from header");
-  printf("\n  <drc_cut_factor> is to set DRC cut factor value. Default value is 0");
-  printf("\n  <drc_boost_factor> is to set DRC boost factor. Default value is 0");
+  printf("\n  <drc_cut_factor> is to set DRC cut factor value. Default value is 1 for USAC path "
+         "and 0 for AAC path");
+  printf("\n  <drc_boost_factor> is to set DRC boost factor. Default value is 1 for USAC path "
+         "and 0 for AAC path");
   printf("\n  <drc_target_level> is to set DRC target reference level.");
   printf("\n    Default value is 108");
   printf("\n  <drc_heavy_compression> is to enable / disable DRC heavy compression.");


### PR DESCRIPTION
Significance:
==============
- This change allows the loudness_leveling CLI parameter to operate independently, without relying on other parameters

Testing:
=========
- Conformance tested for x86, x86_64, armv7, armv8, Mac and MSVS