### PR TITLE
Added a fix in the pvc path for decoder

### DIFF
--- a/README_dec.md
+++ b/README_dec.md
@@ -205,8 +205,8 @@ where,
   <esbr_ps_flag>           is to indicate eSBR with PS. Default 0.
   <interleave_to_stereo>   is to enable/disable always interleaved to stereo output. Default 1.
   <down_sample_sbr>        is to enable/disable down-sampled SBR output. Default auto identification from header.
-  <drc_cut_factor>         is to set DRC cut factor value. Default value is 1 for USAC path and 0 for AAC path.
-  <drc_boost_factor>       is to set DRC boost factor. Default value is 1 for USAC path and 0 for AAC path.
+  <drc_cut_factor>         is to set DRC cut factor value. Default value is 1.
+  <drc_boost_factor>       is to set DRC boost factor. Default value is 1.
   <drc_target_level>       is to set DRC target reference level. Default value is 108.
   <drc_heavy_compression>  is to enable/disable DRC heavy compression. Default value is 0.
   <effect_type>            is to set DRC effect type. Default value is 0.

--- a/decoder/ixheaacd_sbrdecoder.c
+++ b/decoder/ixheaacd_sbrdecoder.c
@@ -638,9 +638,9 @@ IA_ERRORCODE ixheaacd_applysbr(
                                            frame_status);
             }
           } else if (ptr_frame_data[k]->sbr_mode == PVC_SBR) {
-            frame_status = ixheaacd_sbr_read_pvc_sce(ptr_frame_data[k], it_bit_buff, 0,
-                                                     self->ptr_pvc_data_str,
-                                                     self->pstr_sbr_tables, ptr_header_data[k]);
+            frame_status = ixheaacd_sbr_read_pvc_sce(
+                ptr_frame_data[k], it_bit_buff, ptr_header_data[k]->hbe_flag,
+                self->ptr_pvc_data_str, self->pstr_sbr_tables, ptr_header_data[k]);
             if (frame_status < 0) return frame_status;
           }
         }

--- a/test/decoder/ixheaacd_main.c
+++ b/test/decoder/ixheaacd_main.c
@@ -2326,10 +2326,8 @@ void print_usage() {
   printf("\n    interleaved to stereo output. Default 1 ");
   printf("\n  <down_sample_sbr> is to enable/disable down-sampled SBR ");
   printf("\n    output. Default auto identification from header");
-  printf("\n  <drc_cut_factor> is to set DRC cut factor value. Default value is 1 for USAC path "
-         "and 0 for AAC path");
-  printf("\n  <drc_boost_factor> is to set DRC boost factor. Default value is 1 for USAC path "
-         "and 0 for AAC path");
+  printf("\n  <drc_cut_factor> is to set DRC cut factor value. Default value is 1");
+  printf("\n  <drc_boost_factor> is to set DRC boost factor. Default value is 1");
   printf("\n  <drc_target_level> is to set DRC target reference level.");
   printf("\n    Default value is 108");
   printf("\n  <drc_heavy_compression> is to enable / disable DRC heavy compression.");


### PR DESCRIPTION
Significance:
=============
- This change handles PVC path correctly for non-zero PVC modes
- Addressed a minor nit in the usage information

Testing:
========
- Conformance tested for x86, x86_64, armv7, armv8, Mac and MSVS