### PR TITLE
Fix for integer-overflow in ixheaacd_map_index_data

### DIFF
--- a/decoder/ixheaacd_mps_bitdec.c
+++ b/decoder/ixheaacd_mps_bitdec.c
@@ -1448,8 +1448,8 @@ static VOID ixheaacd_factor_cld(WORD32 *idx, WORD32 ott_vs_tot_db, WORD32 *ott_v
   c1 = ixheaacd_mps_dec_bitdec_tables->factor_cld_tab_1[*idx + 15];
   c2 = ixheaacd_mps_dec_bitdec_tables->factor_cld_tab_1[15 - *idx];
 
-  *ott_vs_tot_db_1 = c1 + ott_vs_tot_db;
-  *ott_vs_tot_db_2 = c2 + ott_vs_tot_db;
+  *ott_vs_tot_db_1 = ixheaac_add32_sat(c1, ott_vs_tot_db);
+  *ott_vs_tot_db_2 = ixheaac_add32_sat(c2, ott_vs_tot_db);
 }
 
 static IA_ERRORCODE ixheaacd_map_index_data(


### PR DESCRIPTION
## Significance:
- This change addresses a corner case arithmetic operation involving addition.

Bug: ossFuzz: 486993297
Test: poc in bug

## Testing:
- All previous fuzzer crashes are tested. No crash observed.
- CTS is passing
- Conformance passing on Windows