### PR TITLE
Fix for Null-dereference READ in ixheaacd_local_hybcmdct2qmf

### DIFF
--- a/decoder/ixheaacd_config.h
+++ b/decoder/ixheaacd_config.h
@@ -721,4 +721,6 @@ UWORD32 ixheaacd_sbr_params(UWORD32 core_sbr_frame_len_idx,
 WORD32 ixheaacd_config(ia_bit_buf_struct *bit_buff,
                        ia_usac_config_struct *pstr_usac_conf, UINT32 *chan, WORD32 ec_flag);
 
+FLAG ixheaacd_validate_res_frames_per_spatial_frame(WORD32 num_slots, WORD32 val);
+
 #endif /* IXHEAACD_CONFIG_H */

--- a/decoder/ixheaacd_ld_mps_config.c
+++ b/decoder/ixheaacd_ld_mps_config.c
@@ -59,6 +59,8 @@ static IA_ERRORCODE ixheaacd_ld_spatial_extension_config(
 
   tmp = it_bit_buff->cnt_bits;
 
+  WORD32 num_slots = config->bs_frame_length + 1;
+
   while (ba >= 8) {
     if (config->sac_ext_cnt >= MAX_NUM_EXT_TYPES) return IA_FATAL_ERROR;
 
@@ -91,6 +93,11 @@ static IA_ERRORCODE ixheaacd_ld_spatial_extension_config(
           config->bs_residual_frames_per_spatial_frame =
               ixheaacd_read_bits_buf(it_bit_buff, 2);
 
+          if (!ixheaacd_validate_res_frames_per_spatial_frame(
+                  num_slots, config->bs_residual_frames_per_spatial_frame)) {
+            return IA_FATAL_ERROR;
+          }
+
           if ((config->num_ott_boxes + config->num_ttt_boxes) >
               MAX_RESIDUAL_CHANNELS)
             return IA_FATAL_ERROR;
@@ -118,6 +125,12 @@ static IA_ERRORCODE ixheaacd_ld_spatial_extension_config(
           }
           config->bs_arbitrary_downmix_residual_frames_per_spatial_frame =
               ixheaacd_read_bits_buf(it_bit_buff, 2);
+
+          if (!ixheaacd_validate_res_frames_per_spatial_frame(
+                  num_slots, config->bs_arbitrary_downmix_residual_frames_per_spatial_frame)) {
+            return IA_FATAL_ERROR;
+          }
+
           config->bs_arbitrary_downmix_residual_bands =
               ixheaacd_read_bits_buf(it_bit_buff, 5);
           if (config->bs_arbitrary_downmix_residual_bands >=

--- a/decoder/ixheaacd_mps_bitdec.c
+++ b/decoder/ixheaacd_mps_bitdec.c
@@ -57,6 +57,29 @@ static WORD32 ixheaacd_bound_check(WORD32 var, WORD32 lower_bound, WORD32 upper_
   return var;
 }
 
+FLAG ixheaacd_validate_res_frames_per_spatial_frame(WORD32 num_slots, WORD32 val) {
+  switch (num_slots) {
+    case 15:
+    case 16:
+    case 18:
+    case 24:
+    case 30:
+      return val == 0;
+    case 32:
+      return val == 0 || val == 1;
+    case 36:
+    case 48:
+    case 60:
+      return val == 1;
+    case 64:
+      return val == 1 || val == 3;
+    case 72:
+      return val == 2;
+    default:
+      return 0;
+  }
+}
+
 static VOID ixheaacd_mps_check_index_bounds(
     WORD32 output_idx_data[][MAX_PARAMETER_SETS][MAX_PARAMETER_BANDS],
     WORD32 num_parameter_sets, WORD32 start_band, WORD32 stop_band,
@@ -83,6 +106,8 @@ static IA_ERRORCODE ixheaacd_parse_extension_config(
   WORD32 ba = bits_available;
 
   config->sac_ext_cnt = 0;
+
+  WORD32 num_slots = config->bs_frame_length + 1;
 
   while (ba >= 8) {
     ba -= 8;
@@ -111,6 +136,11 @@ static IA_ERRORCODE ixheaacd_parse_extension_config(
         }
         config->bs_residual_frames_per_spatial_frame = temp & TWO_BIT_MASK;
 
+        if (!ixheaacd_validate_res_frames_per_spatial_frame(
+                num_slots, config->bs_residual_frames_per_spatial_frame)) {
+          return IA_FATAL_ERROR;
+        }
+
         for (i = 0; i < num_ott_boxes + num_ttt_boxes; i++) {
           config->bs_residual_present[i] = ixheaacd_read_bits_buf(it_bit_buff, 1);
           if (config->bs_residual_present[i]) {
@@ -133,6 +163,12 @@ static IA_ERRORCODE ixheaacd_parse_extension_config(
         }
         config->bs_arbitrary_downmix_residual_frames_per_spatial_frame =
             (temp >> 5) & TWO_BIT_MASK;
+
+        if (!ixheaacd_validate_res_frames_per_spatial_frame(
+                num_slots, config->bs_arbitrary_downmix_residual_frames_per_spatial_frame)) {
+          return IA_FATAL_ERROR;
+        }
+
         config->bs_arbitrary_downmix_residual_bands = temp & FIVE_BIT_MASK;
         if (config->bs_arbitrary_downmix_residual_bands >=
             ixheaacd_freq_res_table[config->bs_freq_res]) {


### PR DESCRIPTION
## Significance:

- This change addresses invalid residual frame parameters by ensuring valid value combinations based on the number of time slots as per standard specification.

Bug: ossFuzz: 504009345
Test: poc in bug

## Testing:
- All previous fuzzer crashes are tested. No crash observed.
- CTS is passing.
- Conformance passing on Linux.